### PR TITLE
Bug fixes

### DIFF
--- a/cfn_lbr_registry/Makefile
+++ b/cfn_lbr_registry/Makefile
@@ -78,12 +78,12 @@ deploy: require_bucket $(BUILD_DIR)/$(PACKAGED_TEMPLATE_FILE)
 	--s3-bucket $(BUCKET) \
 	--s3-prefix $(CODE_KEY_PREFIX) \
 	--capabilities CAPABILITY_IAM 2> $(BUILD_DIR)/deploy.err || \
-	sed -e '/^$$/d' $(BUILD_DIR)/deploy.err && \
+	(sed -e '/^$$/d' $(BUILD_DIR)/deploy.err && \
 	if grep -q $(NO_CHANGES_REGEX) $(BUILD_DIR)/deploy.err; then \
 	  rm -f $(BUILD_DIR)/deploy.err; \
 	else \
-	  rm -f $(BUILD_DIR)/deploy.err && false; \
-	fi
+    rm -f $(BUILD_DIR)/deploy.err && false; \
+	fi)
 
 
 .PHONY: clean

--- a/cfn_lbr_registry/Makefile
+++ b/cfn_lbr_registry/Makefile
@@ -52,7 +52,7 @@ $(BUILD_DIR)/$(PACKAGED_TEMPLATE_FILE): require_bucket $(BUILD_DIR)/$(TEMPLATE_F
 	if [ -z "$$OUTPUT" ]; then \
 	  true; \
 	elif echo "$$OUTPUT" | grep -q "404"; then \
-	  echo "Creating code bucket" && aws s3api create-bucket --bucket $(BUCKET) --create-bucket-configuration LocationConstraint=$(REGION); \
+	  echo "Creating code bucket" && aws s3api create-bucket --bucket $(BUCKET); \
 	else \
 	  false; \
 	fi

--- a/cfn_lbr_registry/__main__.py
+++ b/cfn_lbr_registry/__main__.py
@@ -28,10 +28,9 @@ def run_make(action, args, other_args):
 
     makefile = pkg_resources.resource_string(__name__, 'Makefile')
     proc = subprocess.Popen(['make', '-f', '-'] + make_args + [action], stdin=subprocess.PIPE)
-    proc.communicate(makefile)
 
-    out, _ = proc.communicate(makefile)
-    return out
+    proc.communicate(makefile)
+    return proc.returncode
 
 def main():
     parser = argparse.ArgumentParser()

--- a/cfn_lbr_registry/__main__.py
+++ b/cfn_lbr_registry/__main__.py
@@ -25,8 +25,13 @@ from . import parameters
 def run_make(action, args, other_args):
     make_args = []
     make_args += parameters.get_make_args(action, args, other_args)
-    with pkg_resources.resource_stream(__name__, 'Makefile') as fp:
-        return subprocess.call(['make', '-f', '-'] + make_args + [action], stdin=fp)
+
+    makefile = pkg_resources.resource_string(__name__, 'Makefile')
+    proc = subprocess.Popen(['make', '-f', '-'] + make_args + [action], stdin=subprocess.PIPE)
+    proc.communicate(makefile)
+
+    out, _ = proc.communicate(makefile)
+    return out
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
The deploy target was failing because the grep statements were running even when cloudformation was successful.  deploy.err was empty, so the no changes regex would not match, and it would go to the "unexpected error" case and return false.  Throwing in a pair of parentheses fixes the problem.